### PR TITLE
Fix recursive S3 upload support

### DIFF
--- a/pkg/snappy/cassandra.go
+++ b/pkg/snappy/cassandra.go
@@ -154,7 +154,7 @@ func (c *Cassandra) GetSnapshotFiles(id string) map[string]string {
 						log.Fatal(err)
 					}
 					if !info.IsDir() {
-						remotePath := strings.TrimPrefix(path, tableDir)
+						remotePath := strings.TrimPrefix(path, tableDir+"/")
 						s3Files[path] = filepath.Join("backups", id, node, keyspace, table, remotePath)
 					}
 					return nil

--- a/pkg/snappy/cassandra.go
+++ b/pkg/snappy/cassandra.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -141,13 +142,22 @@ func (c *Cassandra) GetSnapshotFiles(id string) map[string]string {
 			}
 
 			for _, table := range tables {
-				files, _ := filepath.Glob(fmt.Sprintf(filepath.Join(dataDir, keyspace, table, "snapshots", id, "*")))
-				for _, file := range files {
-					if f, _ := os.Stat(file); !f.IsDir() {
-						baseFile := filepath.Base(file)
-						s3Files[file] = fmt.Sprintf("backups/%s/%s/%s/%s/%s", id, node, keyspace, table, baseFile)
-					}
+				// check if keyspace, table, snapshot exist
+				tableDir := fmt.Sprintf(filepath.Join(dataDir, keyspace, table, "snapshots", id))
+				if _, err := os.Stat(tableDir); os.IsNotExist(err) {
+					continue
 				}
+
+				filepath.Walk(tableDir, func(path string, info os.FileInfo, err error) error {
+					if err != nil {
+						log.Fatal(err)
+					}
+					if !info.IsDir() {
+						remotePath := strings.TrimLeft(path, tableDir)
+						s3Files[path] = fmt.Sprintf("backups/%s/%s/%s/%s/%s", id, node, keyspace, table, remotePath)
+					}
+					return nil
+				})
 			}
 		}
 	}

--- a/pkg/snappy/cassandra.go
+++ b/pkg/snappy/cassandra.go
@@ -154,8 +154,8 @@ func (c *Cassandra) GetSnapshotFiles(id string) map[string]string {
 						log.Fatal(err)
 					}
 					if !info.IsDir() {
-						remotePath := strings.TrimLeft(path, tableDir)
-						s3Files[path] = fmt.Sprintf("backups/%s/%s/%s/%s/%s", id, node, keyspace, table, remotePath)
+						remotePath := strings.TrimPrefix(path, tableDir)
+						s3Files[path] = filepath.Join("backups", id, node, keyspace, table, remotePath)
 					}
 					return nil
 				})

--- a/pkg/snappy/cassandra.go
+++ b/pkg/snappy/cassandra.go
@@ -107,7 +107,6 @@ func (c *Cassandra) GetSnapshotFiles(id string) map[string]string {
 
 	var (
 		keyspaces []string
-		tables    []string
 		s3Files   = make(map[string]string)
 	)
 	dataDirs := c.GetDataDirectories()
@@ -134,6 +133,8 @@ func (c *Cassandra) GetSnapshotFiles(id string) map[string]string {
 			if err != nil {
 				log.Fatal(err)
 			}
+
+			var tables []string
 
 			for _, file := range files {
 				if file.IsDir() {

--- a/pkg/snappy/cassandra.go
+++ b/pkg/snappy/cassandra.go
@@ -1,7 +1,6 @@
 package snappy
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -144,7 +143,7 @@ func (c *Cassandra) GetSnapshotFiles(id string) map[string]string {
 
 			for _, table := range tables {
 				// check if keyspace, table, snapshot exist
-				tableDir := fmt.Sprintf(filepath.Join(dataDir, keyspace, table, "snapshots", id))
+				tableDir := filepath.Join(dataDir, keyspace, table, "snapshots", id, "/")
 				if _, err := os.Stat(tableDir); os.IsNotExist(err) {
 					continue
 				}
@@ -154,7 +153,7 @@ func (c *Cassandra) GetSnapshotFiles(id string) map[string]string {
 						log.Fatal(err)
 					}
 					if !info.IsDir() {
-						remotePath := strings.TrimPrefix(path, tableDir+"/")
+						remotePath := strings.TrimPrefix(path, tableDir)
 						s3Files[path] = filepath.Join("backups", id, node, keyspace, table, remotePath)
 					}
 					return nil


### PR DESCRIPTION
We were not handling recursive directories correctly. Dont use filepath.Glob(), instead use filepath.Walk() and compute the relative paths on S3.